### PR TITLE
check if there is no setting set, and if not, bail

### DIFF
--- a/inc/AppPresser_Theme_Switcher.php
+++ b/inc/AppPresser_Theme_Switcher.php
@@ -159,6 +159,10 @@ class AppPresser_Theme_Switcher extends AppPresser {
 	 */
 	public function pre_show_on_front() {
 
+		if( !appp_get_setting( 'appp_home_page' ) ) {
+			return false;
+		}
+
 		$this->theme = wp_get_theme();
 		if ( $this->theme->template == $this->maybe_switch() && ! is_admin() ) {
 			return 'page';


### PR DESCRIPTION
Pending confirmation from original bug reporter at http://apppresser.com/support/topic/home-class-removed-by-activating-apppresser-plugin/

Worked for both Ryan and myself locally, once confirmed above, will merge it in.
