### PR TITLE
Fixed typographical error, changed aggresive to aggressive in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ We are happy to accept contributions, but also want to maintain high quality doc
 #### 1.0.3
 * Bug Fix: `plugins_loaded` firing too early causing conflicts with other plugins.
 * Improvement: Check child theme for `app-settings.php` file as well as parent theme.
-* Improvement: Added method for loading AppPresser theme despite aggresively cached web hosts.
+* Improvement: Added method for loading AppPresser theme despite aggressively cached web hosts.
 
 
 #### 1.0.2

--- a/readme.txt
+++ b/readme.txt
@@ -158,7 +158,7 @@ Technically you can do anything with an AppPresser app that you can do with Phon
 = 1.0.3 =
 * Bug Fix: `plugins_loaded` firing too early causing conflicts with other plugins.
 * Improvement: Check child theme for `app-settings.php` file as well as parent theme.
-* Improvement: Added method for loading AppPresser theme despite aggresively cached web hosts.
+* Improvement: Added method for loading AppPresser theme despite aggressively cached web hosts.
 
 = 1.0.2 =
 * Bug Fix: Conflict causing other themes to appear to need an update.
@@ -223,7 +223,7 @@ Technically you can do anything with an AppPresser app that you can do with Phon
 = 1.0.3 =
 * Bug Fix: `plugins_loaded` firing too early causing conflicts with other plugins.
 * Improvement: Check child theme for `app-settings.php` file as well as parent theme.
-* Improvement: Added method for loading AppPresser theme despite aggresively cached web hosts.
+* Improvement: Added method for loading AppPresser theme despite aggressively cached web hosts.
 
 = 1.0.2 =
 * Bug Fix: Conflict causing other themes to appear to need an update.


### PR DESCRIPTION
@WebDevStudios, I've corrected a typographical error in the documentation of the [AppPresser](https://github.com/WebDevStudios/AppPresser) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.